### PR TITLE
Add rsquared to `modelfit_stats`

### DIFF
--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -605,6 +605,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             "redchi",
             "aic",
             "bic",
+            "rsquared",
         ]
 
         _output_wrapper = self._define_output_wrapper(


### PR DESCRIPTION
By adding `rsquared` to `stat_names` we can directly access lmfits internal calculated R² value in the result xarray dataset (variable `modelfit_stats`). Thats a low hanging fruit, and R² is a great add-on to chi².