### PR TITLE
fix: preserve skipna false best-fit masking

### DIFF
--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -208,7 +208,7 @@ def _model_fit_wrapper(
             modres.success = False
             return popt, perr, pcov, stats, data, best, modres
     else:
-        mask = np.full_like(y, True)
+        mask = np.ones_like(y, dtype=bool)
 
     x = np.squeeze(x)
 
@@ -301,7 +301,7 @@ def _model_fit_wrapper(
                                 j = param_names.index(var_names[vj])
                                 pcov[i, j] = modres.covar[vi, vj]
 
-            best.flat[mask] = modres.best_fit
+            best.flat[mask] = modres.best_fit  # type: ignore[index, unused-ignore]
 
     return popt, perr, pcov, stats, data, best, modres
 

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -18,6 +18,10 @@ def power(t, a):
     return np.power(t, a)
 
 
+def linear(x, slope, intercept):
+    return slope * x + intercept
+
+
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])
 @pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
 def test_da_modelfit(
@@ -103,6 +107,21 @@ def test_da_modelfit(
 
     assert "a" in fit.param
     assert fit.modelfit_results.dims == ()
+
+
+def test_da_modelfit_skipna_false_best_fit() -> None:
+    x = np.arange(5, dtype=float)
+    da = xr.DataArray(linear(x, 2.0, 1.0), dims="x", coords={"x": x})
+
+    fit = da.xlm.modelfit(
+        coords="x",
+        model=lmfit.Model(linear),
+        params={"slope": 1.0, "intercept": 0.0},
+        skipna=False,
+    )
+
+    assert np.isfinite(fit.modelfit_best_fit).all()
+    np.testing.assert_allclose(fit.modelfit_best_fit, da)
 
 
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])


### PR DESCRIPTION
## Summary

- keep the fast `best.flat[mask]` assignment while adding a targeted mypy suppression for NumPy flat boolean indexing
- make the `skipna=False` mask explicitly boolean so float data does not produce an invalid float mask
- add a regression test covering `skipna=False` best-fit output

## Root cause

Static type checking started rejecting boolean masks on `ndarray.flat`, even though NumPy supports that path at runtime. The nearby `skipna=False` branch also used `np.full_like(y, True)`, which can inherit `y`'s float dtype and fail as an iterator index.

## Validation

- `uv run mypy --install-types --non-interactive .`
- `uv run pytest`
- `uv run ruff check .`