### PR TITLE
Fix multidimensional fitting and improve Dask performance

### DIFF
--- a/src/xarray_lmfit/_io.py
+++ b/src/xarray_lmfit/_io.py
@@ -2,8 +2,11 @@ import contextlib
 import os
 import threading
 import typing
+import warnings
 from collections.abc import Callable
 
+import numpy as np
+import numpy.typing as npt
 import xarray as xr
 
 if typing.TYPE_CHECKING:
@@ -19,6 +22,10 @@ _ENCODE4JS_PATCH_DEPTH: int = 0
 _ENCODE4JS_ORIG: Callable | None = None
 _ENCODE4JS_PATCHED: Callable | None = None
 _ENCODE4JS_TLS: threading.local = threading.local()
+_SCIPY_DISTRIBUTED_WRITE_ERROR = (
+    "Writing netCDF files with the scipy backend is not currently supported with "
+    "dask's distributed scheduler"
+)
 
 
 @contextlib.contextmanager
@@ -82,8 +89,15 @@ def _patch_encode4js():
                 _ENCODE4JS_PATCHED = None
 
 
-def _dumps_result(result: "lmfit.model.ModelResult") -> str:
-    return result.dumps()
+def _dumps_results(
+    results: npt.NDArray[np.object_],
+) -> npt.NDArray[np.object_]:
+    """Serialize one eager or dask block of model results."""
+    output = np.empty(results.shape, dtype=object)
+    with _patch_encode4js():
+        for i, result in enumerate(results.flat):
+            output.flat[i] = result.dumps()
+    return output
 
 
 def _loads_result(s: str, funcdefs: dict | None = None) -> "lmfit.model.ModelResult":
@@ -136,13 +150,28 @@ def save_fit(result_ds: xr.Dataset, path: str | os.PathLike, **kwargs) -> None:
         for var in ds.data_vars:
             if str(var).endswith("modelfit_results"):
                 ds[var] = xr.apply_ufunc(
-                    _dumps_result,
+                    _dumps_results,
                     ds[var],
-                    vectorize=True,
-                    output_dtypes=[str],
+                    dask="parallelized",
+                    output_dtypes=[object],
                 )
 
-    ds.to_netcdf(path, **kwargs)
+        # Serialized JSON strings have data-dependent lengths, so a fixed-width dask
+        # dtype would either truncate them or waste substantial memory. The backend
+        # intentionally inspects the object array once to select a safe string dtype.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"variable .*modelfit_results has data in the form of a dask "
+                r"array with dtype=object.*",
+                category=xr.SerializationWarning,
+            )
+            try:
+                ds.to_netcdf(path, **kwargs)
+            except NotImplementedError as e:
+                if _SCIPY_DISTRIBUTED_WRITE_ERROR not in str(e):
+                    raise
+                ds.compute().to_netcdf(path, **kwargs)
 
 
 def load_fit(

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -195,7 +195,7 @@ def _model_fit_wrapper(
     y: npt.NDArray = Y.ravel()
 
     if skipna:
-        mask = np.all([np.any(~np.isnan(x), axis=0), ~np.isnan(y)], axis=0)
+        mask = ~np.isnan(y) & ~np.isnan(x).any(axis=0)
         x = x[:, mask]
         y = y[mask]
         if weights_ is not None and not np.isscalar(weights_):

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import copy
 import functools
 import typing
 from collections.abc import Collection, Hashable, Iterable, Mapping, Sequence
@@ -68,20 +67,21 @@ def _parse_params(
     # Iterate over all values to check if any DataArrays are present
     for v in _nested_dict_vals(d):
         if isinstance(v, xr.DataArray):
-            return _parse_multiple_params(copy.deepcopy(d))
+            return _parse_multiple_params(d)
 
     # Can be treated as a single lmfit.Parameters object for all fits
     return _ParametersWrapper(lmfit.create_params(**d))
 
 
 def _parse_multiple_params(d: dict[str, typing.Any]) -> xr.DataArray:
-    for k in d:
-        if isinstance(d[k], int | float | complex | xr.DataArray):
-            d[k] = {"value": d[k]}
+    parsed = {}
+    for k, value in d.items():
+        if isinstance(value, int | float | complex | xr.DataArray):
+            value = {"value": value}
 
-        d[k] = _concat_along_keys(_broadcast_dict_values(d[k]), "__dict_keys")
+        parsed[k] = _concat_along_keys(_broadcast_dict_values(value), "__dict_keys")
 
-    da = _concat_along_keys(_broadcast_dict_values(d), "__param_names")
+    da = _concat_along_keys(_broadcast_dict_values(parsed), "__param_names")
 
     pnames = tuple(da["__param_names"].values)
     argnames = tuple(da["__dict_keys"].values)

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -134,6 +134,7 @@ def _model_fit_wrapper(
     skipna: bool,
     guess: bool,
     errors: typing.Literal["raise", "ignore"],
+    output_result: bool,
     model_fit_kwargs: Mapping[str, typing.Any] | None = None,
 ):
     """Top-level wrapper for Model.fit to keep dask graphs picklable."""
@@ -202,6 +203,8 @@ def _model_fit_wrapper(
             weights_ = weights_[mask]
         if not len(y):
             # No data to fit
+            if not output_result:
+                return popt, perr, pcov, stats, data, best
             modres = lmfit.model.ModelResult(
                 model, initial_params, data=y, weights=weights_
             )
@@ -256,6 +259,8 @@ def _model_fit_wrapper(
     except ValueError:
         if errors == "raise":
             raise
+        if not output_result:
+            return popt, perr, pcov, stats, data, best
         modres = lmfit.model.ModelResult(
             model, initial_params, data=y, weights=weights_
         )
@@ -303,7 +308,10 @@ def _model_fit_wrapper(
 
             best.flat[mask] = modres.best_fit  # type: ignore[index, unused-ignore]
 
-    return popt, perr, pcov, stats, data, best, modres
+    outputs = (popt, perr, pcov, stats, data, best)
+    if output_result:
+        return (*outputs, modres)
+    return outputs
 
 
 @register_xlm_dataset_accessor("modelfit")
@@ -319,6 +327,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
         skipna: bool,
         guess: bool,
         errors: typing.Literal["raise", "ignore"],
+        output_result: bool,
         model_fit_kwargs: Mapping[str, typing.Any],
     ):
         """Define a picklable wrapper for the model fitting."""
@@ -331,6 +340,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             skipna=skipna,
             guess=guess,
             errors=errors,
+            output_result=output_result,
             model_fit_kwargs=model_fit_kwargs,
         )
 
@@ -358,6 +368,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             skipna=skipna,
             guess=guess,
             errors=errors,
+            output_result=output_result,
             model_fit_kwargs=model_fit_kwargs,
         )
         n_params = len(param_names)
@@ -399,21 +410,26 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
                 # Core dims for weights
                 input_core_dims.append([d for d in reduce_dims_ if d in weights.dims])
 
-            popt, perr, pcov, stats, data, best, modres = xr.apply_ufunc(
+            output_core_dims: list[list[Hashable]] = [
+                ["param"],
+                ["param"],
+                ["cov_i", "cov_j"],
+                ["fit_stat"],
+                reduce_dims_,
+                reduce_dims_,
+            ]
+            output_dtypes: list[typing.Any] = [np.float64] * 6
+            if output_result:
+                output_core_dims.append([])
+                output_dtypes.append(lmfit.model.ModelResult)
+
+            outputs = xr.apply_ufunc(
                 _wrapper,
                 *args,
                 vectorize=True,
                 dask="parallelized",
                 input_core_dims=input_core_dims,
-                output_core_dims=[
-                    ["param"],
-                    ["param"],
-                    ["cov_i", "cov_j"],
-                    ["fit_stat"],
-                    reduce_dims_,
-                    reduce_dims_,
-                    [],
-                ],
+                output_core_dims=output_core_dims,
                 dask_gufunc_kwargs={
                     "output_sizes": {
                         "param": n_params,
@@ -423,20 +439,13 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
                     }
                     | dim_sizes
                 },
-                output_dtypes=(
-                    np.float64,
-                    np.float64,
-                    np.float64,
-                    np.float64,
-                    np.float64,
-                    np.float64,
-                    lmfit.model.ModelResult,
-                ),
+                output_dtypes=output_dtypes,
                 exclude_dims=set(reduce_dims_),
             )
+            popt, perr, pcov, stats, data, best = outputs[:6]
 
             if output_result:
-                out[name + "modelfit_results"] = modres
+                out[name + "modelfit_results"] = outputs[6]
 
             out[name + "modelfit_coefficients"] = popt
             out[name + "modelfit_stderr"] = perr

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ import tempfile
 
 import lmfit
 import numpy as np
+import pytest
 import xarray as xr
 
 from xarray_lmfit import load_fit, save_fit
@@ -39,6 +40,49 @@ def test_darr_io() -> None:
             loaded_ds.drop_vars("modelfit_results"),
             result_ds.drop_vars("modelfit_results"),
         )
+
+
+@pytest.mark.parametrize(
+    "use_client", [False, True], ids=["local-scheduler", "distributed-client"]
+)
+def test_darr_io_dask(use_client: bool) -> None:
+    client = None
+    if use_client:
+        from dask.distributed import Client
+
+        client = Client(n_workers=1, threads_per_worker=1)
+
+    x = np.linspace(0, 10, 50)
+    y = np.stack([2.0 * x + 1.0, -0.5 * x + 3.0])
+    y_arr = xr.DataArray(
+        y,
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    ).chunk({"fit": 1})
+
+    model = lmfit.models.LinearModel()
+    result_ds = y_arr.xlm.modelfit(
+        "x",
+        model=model,
+        params=model.make_params(slope=1.0, intercept=0.0),
+    )
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".nc") as tmp:
+            save_fit(result_ds, tmp.name)
+            loaded_ds = load_fit(tmp.name)
+
+        assert all(
+            isinstance(result.item(), lmfit.model.ModelResult)
+            for result in loaded_ds["modelfit_results"]
+        )
+        xr.testing.assert_identical(
+            loaded_ds.drop_vars("modelfit_results"),
+            result_ds.drop_vars("modelfit_results").compute(),
+        )
+    finally:
+        if client is not None:
+            client.shutdown()
 
 
 def test_ds_io() -> None:

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -124,6 +124,39 @@ def test_da_modelfit_skipna_false_best_fit() -> None:
     np.testing.assert_allclose(fit.modelfit_best_fit, da)
 
 
+def test_da_modelfit_skipna_multiple_coords() -> None:
+    def plane(x, z, slope_x, slope_z, intercept):
+        return slope_x * x + slope_z * z + intercept
+
+    x = np.arange(6, dtype=float)
+    z = np.array([0.0, 2.0, 1.0, 4.0, 3.0, 1.0])
+    da = xr.DataArray(plane(x, z, 2.0, -0.5, 1.0), dims="point")
+
+    x_coord = xr.DataArray(x, dims="point")
+    z_coord = xr.DataArray(z, dims="point")
+    x_coord[2] = np.nan
+    z_coord[4] = np.nan
+
+    fit = da.xlm.modelfit(
+        coords=[x_coord, z_coord],
+        model=lmfit.Model(plane, independent_vars=["x", "z"]),
+        reduce_dims="point",
+        params={"slope_x": 1.0, "slope_z": 0.0, "intercept": 0.0},
+    )
+
+    np.testing.assert_allclose(
+        fit.modelfit_coefficients,
+        [2.0, -0.5, 1.0],
+        rtol=1e-7,
+        atol=1e-7,
+    )
+    assert np.isnan(fit.modelfit_best_fit[[2, 4]]).all()
+    np.testing.assert_allclose(
+        fit.modelfit_best_fit[[0, 1, 3, 5]],
+        da[[0, 1, 3, 5]],
+    )
+
+
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])
 @pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
 def test_ds_modelfit(

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -157,6 +157,42 @@ def test_da_modelfit_skipna_multiple_coords() -> None:
     )
 
 
+@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
+def test_da_modelfit_without_model_results(
+    use_dask: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dtypes = []
+    apply_ufunc = xr.apply_ufunc
+
+    def capture_output_dtypes(*args, **kwargs):
+        output_dtypes.append(tuple(kwargs["output_dtypes"]))
+        return apply_ufunc(*args, **kwargs)
+
+    monkeypatch.setattr(xr, "apply_ufunc", capture_output_dtypes)
+
+    x = np.arange(5, dtype=float)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 1.0), np.full_like(x, np.nan)]),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    if use_dask:
+        da = da.chunk({"fit": 1})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params={"slope": 1.0, "intercept": 0.0},
+        output_result=False,
+    ).compute()
+
+    assert output_dtypes == [(np.float64,) * 6]
+    assert "modelfit_results" not in fit
+    assert all(variable.dtype != object for variable in fit.data_vars.values())
+    np.testing.assert_allclose(fit.modelfit_coefficients[0], [2.0, 1.0])
+    assert np.isnan(fit.modelfit_coefficients[1]).all()
+
+
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])
 @pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
 def test_ds_modelfit(

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -331,6 +331,40 @@ def test_modelfit_params(use_dask: bool, progress: bool) -> None:
     np.testing.assert_allclose(fit.modelfit_coefficients, expected, atol=1e-8)
 
 
+def test_modelfit_does_not_deepcopy_parameter_dataarrays() -> None:
+    class UncopyableDataArray(xr.DataArray):
+        __slots__ = ()
+
+        def __deepcopy__(self, memo):
+            raise AssertionError("parameter DataArrays must not be deep-copied")
+
+    def linear_batch(t, slope, intercept):
+        return slope * t + intercept
+
+    t = np.linspace(0, 1, 10)
+    da = xr.DataArray(
+        np.stack([linear_batch(t, 2.0, 1.0), linear_batch(t, -0.5, 3.0)]),
+        dims=("fit", "t"),
+        coords={"fit": [0, 1], "t": t},
+    )
+    slope_guess = UncopyableDataArray(
+        [1.0, -1.0],
+        dims="fit",
+        coords={"fit": da["fit"]},
+    )
+
+    fit = da.xlm.modelfit(
+        "t",
+        model=lmfit.Model(linear_batch),
+        params={"slope": slope_guess, "intercept": 0.0},
+    )
+
+    np.testing.assert_allclose(
+        fit.modelfit_coefficients,
+        [[2.0, 1.0], [-0.5, 3.0]],
+    )
+
+
 def test_modelfit_expr() -> None:
     # Generate 2 lorentzian peaks on linear bkg and add poisson noise
     xval = np.linspace(-1, 1, 250)


### PR DESCRIPTION
## Summary

- Skip samples with missing values in any independent coordinate during multidimensional fits.
- Save lazy Dask-backed fit results without requiring callers to compute them first, including when a distributed client is active.
- Avoid deep-copying DataArray parameter values while normalizing broadcast parameters.
- Omit the full ModelResult gufunc output when `output_result=False`.

## Why

The multidimensional `skipna` mask previously retained a sample when only one independent coordinate was valid, allowing NaNs to reach lmfit. The save path used an eager-only serialization call and could not handle Dask-backed result arrays. Parameter normalization copied complete DataArray buffers, and disabling full result output still created and retained an object output internally.

These changes correct the two failing workflows and reduce unnecessary memory use during large broadcast fits.

## Validation

- `uv run pytest` (26 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
