### PR TITLE
Fix lazy fit I/O and parameter edge cases

### DIFF
--- a/src/xarray_lmfit/_io.py
+++ b/src/xarray_lmfit/_io.py
@@ -146,15 +146,25 @@ def save_fit(result_ds: xr.Dataset, path: str | os.PathLike, **kwargs) -> None:
 
     """
     ds = result_ds.copy()
+    result_vars = [var for var in ds.data_vars if str(var).endswith("modelfit_results")]
+    has_lazy_results = any(ds[var].chunks is not None for var in result_vars)
+
     with _patch_encode4js():
-        for var in ds.data_vars:
-            if str(var).endswith("modelfit_results"):
-                ds[var] = xr.apply_ufunc(
-                    _dumps_results,
-                    ds[var],
-                    dask="parallelized",
-                    output_dtypes=[object],
-                )
+        for var in result_vars:
+            ds[var] = xr.apply_ufunc(
+                _dumps_results,
+                ds[var],
+                dask="parallelized",
+                output_dtypes=[object],
+            )
+
+        # NetCDF backends inspect object arrays eagerly to determine a string dtype. If
+        # that inspection and the subsequent write evaluate the shared fitting graph
+        # independently, every fit runs twice and stateful models can produce an
+        # inconsistent snapshot. Persist every output in one shared computation while
+        # retaining the chunks/futures used by the backend write.
+        if has_lazy_results:
+            ds = ds.persist()
 
         # Serialized JSON strings have data-dependent lengths, so a fixed-width dask
         # dtype would either truncate them or waste substantial memory. The backend

--- a/src/xarray_lmfit/_io.py
+++ b/src/xarray_lmfit/_io.py
@@ -145,6 +145,13 @@ def save_fit(result_ds: xr.Dataset, path: str | os.PathLike, **kwargs) -> None:
         Function to load the saved fit results.
 
     """
+    if not kwargs.get("compute", True):
+        raise ValueError(
+            "save_fit does not support compute=False because deferred NetCDF writes "
+            "cannot serialize lazy model results consistently. Pass a lazy result "
+            "with the default compute=True to evaluate it once before writing."
+        )
+
     ds = result_ds.copy()
     result_vars = [var for var in ds.data_vars if str(var).endswith("modelfit_results")]
     has_lazy_results = any(ds[var].chunks is not None for var in result_vars)

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -128,7 +128,7 @@ def _make_failed_model_result(
     model: lmfit.Model,
     initial_params: lmfit.Parameters,
     data: npt.NDArray,
-    weights: npt.NDArray | float | None,
+    weights: npt.NDArray | complex | None,
     independent_vars: Mapping[str, typing.Any],
 ) -> lmfit.model.ModelResult:
     """Create a failed result that can be serialized and reconstructed by lmfit."""
@@ -169,9 +169,19 @@ def _model_fit_wrapper(
     fit_kwargs = dict(model_fit_kwargs) if model_fit_kwargs is not None else {}
     if len(args) > n_coords + 1:
         fit_kwargs.pop("weights", None)
-        weights_ = args[n_coords + 1].ravel()
+        raw_weights = args[n_coords + 1]
     else:
-        weights_ = fit_kwargs.pop("weights", None)
+        raw_weights = fit_kwargs.pop("weights", None)
+
+    weights_: npt.NDArray | complex | None
+    if raw_weights is None:
+        weights_ = None
+    else:
+        weights_array = np.asarray(raw_weights)
+        if weights_array.ndim == 0:
+            weights_ = typing.cast("complex", weights_array.item())
+        else:
+            weights_ = weights_array.ravel()
 
     initial_params = lmfit.create_params() if guess else model.make_params()
 
@@ -224,11 +234,17 @@ def _model_fit_wrapper(
     x = np.vstack([c.ravel() for c in coords__])
     y: npt.NDArray = Y.ravel()
 
+    if isinstance(weights_, np.ndarray) and weights_.size != y.size:
+        raise ValueError(
+            "weights must be a scalar or have the same size as the data being fit; "
+            f"received {weights_.size} weights for {y.size} data points"
+        )
+
     if skipna:
         mask = ~np.isnan(y) & ~np.isnan(x).any(axis=0)
         x = x[:, mask]
         y = y[mask]
-        if weights_ is not None and not np.isscalar(weights_):
+        if isinstance(weights_, np.ndarray):
             weights_ = weights_[mask]
     else:
         mask = np.ones_like(y, dtype=bool)

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -219,7 +219,7 @@ def _model_fit_wrapper(
     pcov = np.full([n_params, n_params], np.nan)
     stats = np.full([n_stats], np.nan)
     data = Y.copy()
-    best = np.full_like(data, np.nan)
+    best = np.full(data.shape, np.nan, dtype=np.float64)
 
     x = np.vstack([c.ravel() for c in coords__])
     y: npt.NDArray = Y.ravel()

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -207,6 +207,13 @@ def _model_fit_wrapper(
     elif isinstance(init_params_, lmfit.Parameters):
         initial_params.update(init_params_)
 
+    elif isinstance(init_params_, Mapping):
+        param_specs = {
+            name: dict(value) if isinstance(value, Mapping) else {"value": value}
+            for name, value in init_params_.items()
+        }
+        initial_params.update(lmfit.create_params(**param_specs))
+
     popt = np.full([n_params], np.nan)
     perr = np.full([n_params], np.nan)
     pcov = np.full([n_params, n_params], np.nan)

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -38,25 +38,6 @@ def _nested_dict_vals(d) -> Iterable[typing.Any]:
             yield v
 
 
-def _broadcast_dict_values(d: dict[str, typing.Any]) -> dict[str, xr.DataArray]:
-    """Broadcast all values in a dictionary to DataArrays with matching dimensions."""
-    to_broadcast = {}
-    for k, v in d.items():
-        if isinstance(v, xr.DataArray | xr.Dataset):
-            to_broadcast[k] = v
-        else:
-            to_broadcast[k] = xr.DataArray(v)
-
-    d = dict(
-        zip(to_broadcast.keys(), xr.broadcast(*to_broadcast.values()), strict=True)
-    )
-    return typing.cast("dict[str, xr.DataArray]", d)
-
-
-def _concat_along_keys(d: dict[str, xr.DataArray], dim_name: str) -> xr.DataArray:
-    return xr.concat(d.values(), d.keys(), coords="minimal").rename(concat_dim=dim_name)
-
-
 def _parse_params(
     d: dict[str, typing.Any] | lmfit.Parameters,
 ) -> xr.DataArray | _ParametersWrapper:
@@ -73,44 +54,42 @@ def _parse_params(
     return _ParametersWrapper(lmfit.create_params(**d))
 
 
+def _build_params_from_values(
+    *values: typing.Any, keys: Sequence[tuple[str, str]]
+) -> lmfit.Parameters:
+    parsed: dict[str, dict[str, typing.Any]] = {}
+    for (param_name, attr_name), value in zip(keys, values, strict=True):
+        try:
+            is_missing = bool(np.isnan(value))
+        except TypeError:
+            is_missing = False
+
+        if not is_missing:
+            parsed.setdefault(param_name, {})[attr_name] = value
+
+    return lmfit.create_params(**parsed)
+
+
 def _parse_multiple_params(d: dict[str, typing.Any]) -> xr.DataArray:
-    parsed = {}
-    for k, value in d.items():
-        if isinstance(value, int | float | complex | xr.DataArray):
-            value = {"value": value}
+    keys: list[tuple[str, str]] = []
+    values: list[xr.DataArray] = []
+    for param_name, value in d.items():
+        attrs = value if isinstance(value, Mapping) else {"value": value}
+        for attr_name, attr_value in attrs.items():
+            keys.append((param_name, attr_name))
+            if isinstance(attr_value, xr.DataArray):
+                values.append(attr_value)
+            else:
+                values.append(xr.DataArray(attr_value))
 
-        parsed[k] = _concat_along_keys(_broadcast_dict_values(value), "__dict_keys")
-
-    da = _concat_along_keys(_broadcast_dict_values(parsed), "__param_names")
-
-    pnames = tuple(da["__param_names"].values)
-    argnames = tuple(da["__dict_keys"].values)
-
-    def _reduce_to_param(arr, axis=0):
-        axes = (axis,) if np.isscalar(axis) else tuple(axis)
-        axes = tuple(a if a >= 0 else a + arr.ndim for a in axes)
-        axes_set = set(axes)
-        out_arr = np.empty(
-            tuple(s for i, s in enumerate(arr.shape) if i not in axes_set), dtype=object
-        )
-        for i in range(out_arr.size):
-            out_arr.flat[i] = {}
-
-        for i, par in enumerate(pnames):
-            for j, name in enumerate(argnames):
-                for k, val in enumerate(arr[i, j].flat):
-                    if par not in out_arr.flat[k]:
-                        out_arr.flat[k][par] = {}
-
-                    if isinstance(val, str) or np.isfinite(val):
-                        out_arr.flat[k][par][name] = val
-
-        for i in range(out_arr.size):
-            out_arr.flat[i] = lmfit.create_params(**out_arr.flat[i])
-
-        return out_arr
-
-    return da.reduce(_reduce_to_param, ("__dict_keys", "__param_names"))
+    return xr.apply_ufunc(
+        functools.partial(_build_params_from_values, keys=tuple(keys)),
+        *values,
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[object],
+        join="outer",
+    )
 
 
 class _ParametersWrapper:

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -124,6 +124,28 @@ class _ParametersWrapper:
         self.params = params
 
 
+def _make_failed_model_result(
+    model: lmfit.Model,
+    initial_params: lmfit.Parameters,
+    data: npt.NDArray,
+    weights: npt.NDArray | float | None,
+    independent_vars: Mapping[str, typing.Any],
+) -> lmfit.model.ModelResult:
+    """Create a failed result that can be serialized and reconstructed by lmfit."""
+    modres = lmfit.model.ModelResult(
+        model,
+        initial_params,
+        data=data,
+        weights=weights,
+        fcn_args=(data, weights),
+        fcn_kws=independent_vars,
+    )
+    modres.init_values = model._make_all_args(modres.init_params)
+    modres.best_values = model._make_all_args(modres.params)
+    modres.success = False
+    return modres
+
+
 def _model_fit_wrapper(
     Y: npt.NDArray,
     *args,
@@ -201,15 +223,6 @@ def _model_fit_wrapper(
         y = y[mask]
         if weights_ is not None and not np.isscalar(weights_):
             weights_ = weights_[mask]
-        if not len(y):
-            # No data to fit
-            if not output_result:
-                return popt, perr, pcov, stats, data, best
-            modres = lmfit.model.ModelResult(
-                model, initial_params, data=y, weights=weights_
-            )
-            modres.success = False
-            return popt, perr, pcov, stats, data, best, modres
     else:
         mask = np.ones_like(y, dtype=bool)
 
@@ -227,6 +240,15 @@ def _model_fit_wrapper(
             )
     else:
         raise ValueError("Independent variables not defined in model")
+
+    if skipna and not len(y):
+        # No data to fit
+        if not output_result:
+            return popt, perr, pcov, stats, data, best
+        modres = _make_failed_model_result(
+            model, initial_params, y, weights_, indep_var_kwargs
+        )
+        return popt, perr, pcov, stats, data, best, modres
 
     if guess:
         if isinstance(model, lmfit.model.CompositeModel):
@@ -261,10 +283,9 @@ def _model_fit_wrapper(
             raise
         if not output_result:
             return popt, perr, pcov, stats, data, best
-        modres = lmfit.model.ModelResult(
-            model, initial_params, data=y, weights=weights_
+        modres = _make_failed_model_result(
+            model, initial_params, y, weights_, indep_var_kwargs
         )
-        modres.success = False
         return popt, perr, pcov, stats, data, best, modres
     else:
         if modres.success:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -120,6 +120,16 @@ def test_darr_io_dask_evaluates_fit_once() -> None:
     assert expected_calls == _FIT_CALLS
 
 
+@pytest.mark.parametrize("compute", [False, np.bool_(False)])
+def test_save_fit_rejects_deferred_writes(tmp_path, compute: bool) -> None:
+    path = tmp_path / "fit.nc"
+
+    with pytest.raises(ValueError, match="does not support compute=False"):
+        save_fit(xr.Dataset({"value": ("x", [1.0])}), path, compute=compute)
+
+    assert not path.exists()
+
+
 def test_ds_io() -> None:
     # Generate toy data
     x = np.linspace(0, 10, 50)[:, np.newaxis]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -7,6 +7,14 @@ import xarray as xr
 
 from xarray_lmfit import load_fit, save_fit
 
+_FIT_CALLS = 0
+
+
+def _counted_linear(x, slope, intercept):
+    global _FIT_CALLS
+    _FIT_CALLS += 1
+    return slope * x + intercept
+
 
 def test_darr_io() -> None:
     # Generate toy data
@@ -83,6 +91,33 @@ def test_darr_io_dask(use_client: bool) -> None:
     finally:
         if client is not None:
             client.shutdown()
+
+
+def test_darr_io_dask_evaluates_fit_once() -> None:
+    global _FIT_CALLS
+
+    x = np.linspace(0, 1, 10)
+    y_arr = xr.DataArray(
+        (2.0 * x + 1.0)[np.newaxis, :],
+        dims=("fit", "x"),
+        coords={"fit": [0], "x": x},
+    ).chunk({"fit": 1})
+    result_ds = y_arr.xlm.modelfit(
+        "x",
+        model=lmfit.Model(_counted_linear),
+        params={"slope": 1.0, "intercept": 0.0},
+    )
+
+    _FIT_CALLS = 0
+    result_ds.compute()
+    expected_calls = _FIT_CALLS
+
+    _FIT_CALLS = 0
+    with tempfile.NamedTemporaryFile(suffix=".nc") as tmp:
+        save_fit(result_ds, tmp.name)
+
+    assert expected_calls > 0
+    assert expected_calls == _FIT_CALLS
 
 
 def test_ds_io() -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -130,6 +130,38 @@ def test_save_fit_rejects_deferred_writes(tmp_path, compute: bool) -> None:
     assert not path.exists()
 
 
+@pytest.mark.parametrize("skipna", [True, False], ids=["empty", "fit-error"])
+def test_failed_results_roundtrip(skipna: bool) -> None:
+    x = np.arange(5.0)
+    failed_data = np.full_like(x, np.nan)
+    if not skipna:
+        failed_data[0] = 1.0
+    y_arr = xr.DataArray(
+        np.stack([2.0 * x + 1.0, failed_data]),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    result_ds = y_arr.xlm.modelfit(
+        "x",
+        model=lmfit.models.LinearModel(),
+        params={"slope": 1.0, "intercept": 0.0},
+        skipna=skipna,
+        errors="ignore",
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".nc") as tmp:
+        save_fit(result_ds, tmp.name)
+        loaded_ds = load_fit(tmp.name)
+
+    assert loaded_ds.modelfit_results[0].item().success
+    failed_result = loaded_ds.modelfit_results[1].item()
+    assert not failed_result.success
+    if skipna:
+        assert failed_result.data.size == 0
+    else:
+        np.testing.assert_equal(failed_result.data, failed_data)
+
+
 def test_ds_io() -> None:
     # Generate toy data
     x = np.linspace(0, 10, 50)[:, np.newaxis]

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -462,6 +462,34 @@ def test_modelfit_dataarray_dict_params(use_dask: bool) -> None:
     assert "is_init_value" not in param_specs[0]["slope"]
 
 
+def test_modelfit_lazy_broadcast_params() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 1.0), linear(x, -1.0, 3.0)]),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    slope_guess = xr.DataArray([0.0, 0.0], dims="fit", coords={"fit": da.fit}).chunk(
+        {"fit": 1}
+    )
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params={
+            "slope": {"value": slope_guess, "vary": False, "expr": None},
+            "intercept": np.float32(0.0),
+        },
+        output_result=False,
+    )
+
+    assert fit.modelfit_coefficients.chunks is not None
+    np.testing.assert_allclose(
+        fit.compute().modelfit_coefficients,
+        [[0.0, 5.0], [0.0, 1.0]],
+    )
+
+
 def test_modelfit_does_not_deepcopy_parameter_dataarrays() -> None:
     class UncopyableDataArray(xr.DataArray):
         __slots__ = ()

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -367,6 +367,35 @@ def test_modelfit_params(use_dask: bool, progress: bool) -> None:
     np.testing.assert_allclose(fit.modelfit_coefficients, expected, atol=1e-8)
 
 
+@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
+def test_modelfit_dataarray_dict_params(use_dask: bool) -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 1.0), linear(x, -1.0, 3.0)]),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    if use_dask:
+        da = da.chunk({"fit": 1})
+
+    param_specs = np.empty(2, dtype=object)
+    param_specs[:] = [
+        {"slope": {"value": 0.0, "vary": False}, "intercept": 0.0},
+        {"slope": {"value": 0.0, "vary": False}, "intercept": 0.0},
+    ]
+    params = xr.DataArray(param_specs, dims="fit", coords={"fit": da.fit})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params=params,
+        output_result=False,
+    ).compute()
+
+    np.testing.assert_allclose(fit.modelfit_coefficients, [[0.0, 5.0], [0.0, 1.0]])
+    assert "is_init_value" not in param_specs[0]["slope"]
+
+
 def test_modelfit_does_not_deepcopy_parameter_dataarrays() -> None:
     class UncopyableDataArray(xr.DataArray):
         __slots__ = ()

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -147,6 +147,49 @@ def test_da_modelfit_integer_best_fit(use_dask: bool) -> None:
     np.testing.assert_allclose(fit.modelfit_best_fit, expected)
 
 
+@pytest.mark.parametrize(
+    "weights",
+    [
+        np.arange(1.0, 7.0).reshape(2, 3),
+        np.arange(1.0, 7.0).reshape(2, 3).tolist(),
+        np.array(0.1),
+    ],
+    ids=["ndarray", "list", "zero-dimensional"],
+)
+def test_da_modelfit_multidimensional_array_weights(weights) -> None:
+    def plane(x, z, slope_x, slope_z, intercept):
+        return slope_x * x + slope_z * z + intercept
+
+    x, z = np.meshgrid(np.arange(2.0), np.arange(3.0), indexing="ij")
+    values = plane(x, z, 2.0, -0.5, 1.0)
+    values[1, 1] = np.nan
+    da = xr.DataArray(values, dims=("x", "z"))
+
+    fit = da.xlm.modelfit(
+        coords=[xr.DataArray(x, dims=da.dims), xr.DataArray(z, dims=da.dims)],
+        reduce_dims=da.dims,
+        model=lmfit.Model(plane, independent_vars=["x", "z"]),
+        params={"slope_x": 1.0, "slope_z": 0.0, "intercept": 0.0},
+        weights=weights,
+        output_result=False,
+    )
+
+    np.testing.assert_allclose(fit.modelfit_coefficients, [2.0, -0.5, 1.0])
+
+
+def test_da_modelfit_rejects_wrong_weight_size() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(linear(x, 2.0, 1.0), dims="x", coords={"x": x})
+
+    with pytest.raises(ValueError, match="same size as the data being fit"):
+        da.xlm.modelfit(
+            "x",
+            model=lmfit.Model(linear),
+            params={"slope": 1.0, "intercept": 0.0},
+            weights=np.ones(3),
+        )
+
+
 def test_da_modelfit_skipna_multiple_coords() -> None:
     def plane(x, z, slope_x, slope_z, intercept):
         return slope_x * x + slope_z * z + intercept

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -124,6 +124,29 @@ def test_da_modelfit_skipna_false_best_fit() -> None:
     np.testing.assert_allclose(fit.modelfit_best_fit, da)
 
 
+@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
+def test_da_modelfit_integer_best_fit(use_dask: bool) -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.array([0, 1, 5, 9, 13], dtype=np.int64),
+        dims="x",
+        coords={"x": x},
+    )
+    if use_dask:
+        da = da.chunk({"x": -1})
+
+    fit = da.xlm.modelfit(
+        coords="x",
+        model=lmfit.Model(linear),
+        params={"slope": 1.0, "intercept": 0.0},
+        output_result=False,
+    ).compute()
+
+    expected = linear(x, *fit.modelfit_coefficients.values)
+    assert fit.modelfit_best_fit.dtype == np.float64
+    np.testing.assert_allclose(fit.modelfit_best_fit, expected)
+
+
 def test_da_modelfit_skipna_multiple_coords() -> None:
     def plane(x, z, slope_x, slope_z, intercept):
         return slope_x * x + slope_z * z + intercept


### PR DESCRIPTION
## Summary

- save lazy fit results from one persisted evaluation so serialized and numeric outputs stay consistent
- reject unsupported `compute=False` writes instead of leaving partially written NetCDF files
- round-trip skipped and failed `ModelResult` objects, including all-NaN fits
- restore documented per-fit dictionary parameters stored in DataArrays
- preserve floating-point best-fit curves for integer-valued observations
- accept multidimensional array-like weights with clear size validation
- keep broadcast parameter construction lazy while supporting Dask arrays, NumPy scalars, expressions, and explicit `None` values

## Why

A targeted runtime audit found several paths that were not covered by the existing green suite. Lazy NetCDF serialization evaluated the shared fit graph separately for string dtype discovery and file writing, which doubled work and could mix results from different evaluations. Other edge cases either discarded documented parameter inputs, truncated fitted curves to the input dtype, or failed during broadcasting and serialization.

## User impact

Lazy results can now be saved without manually computing them and without re-running each fit. Failed fits survive save/load round trips, integer count data retains fractional fitted curves, and parameter and weight inputs behave consistently across eager and Dask-backed workflows.

Deferred NetCDF writes remain unsupported: `save_fit(..., compute=False)` now raises a clear error instead of returning `None` after creating an invalid file.

## Validation

- `uv run pytest -q` — 40 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src`
- `uv run pre-commit run --all-files`
- `uv run cz check --rev-range origin/main..HEAD`
