### PR TITLE
perf(modelfit): reduce repeated fitting and Dask graph overhead

### DIFF
--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import functools
 import typing
 from collections.abc import Collection, Hashable, Iterable, Mapping, Sequence
@@ -29,69 +30,6 @@ else:
     lmfit = _lazy.load("lmfit")
 
 
-def _nested_dict_vals(d) -> Iterable[typing.Any]:
-    """Recursively yield all "leaf" values in a nested dictionary."""
-    for v in d.values():
-        if isinstance(v, Mapping):
-            yield from _nested_dict_vals(v)
-        else:
-            yield v
-
-
-def _parse_params(
-    d: dict[str, typing.Any] | lmfit.Parameters,
-) -> xr.DataArray | _ParametersWrapper:
-    if isinstance(d, lmfit.Parameters):
-        # Input to apply_ufunc cannot be a Mapping, so wrap in a class
-        return _ParametersWrapper(d)
-
-    # Iterate over all values to check if any DataArrays are present
-    for v in _nested_dict_vals(d):
-        if isinstance(v, xr.DataArray):
-            return _parse_multiple_params(d)
-
-    # Can be treated as a single lmfit.Parameters object for all fits
-    return _ParametersWrapper(lmfit.create_params(**d))
-
-
-def _build_params_from_values(
-    *values: typing.Any, keys: Sequence[tuple[str, str]]
-) -> lmfit.Parameters:
-    parsed: dict[str, dict[str, typing.Any]] = {}
-    for (param_name, attr_name), value in zip(keys, values, strict=True):
-        try:
-            is_missing = bool(np.isnan(value))
-        except TypeError:
-            is_missing = False
-
-        if not is_missing:
-            parsed.setdefault(param_name, {})[attr_name] = value
-
-    return lmfit.create_params(**parsed)
-
-
-def _parse_multiple_params(d: dict[str, typing.Any]) -> xr.DataArray:
-    keys: list[tuple[str, str]] = []
-    values: list[xr.DataArray] = []
-    for param_name, value in d.items():
-        attrs = value if isinstance(value, Mapping) else {"value": value}
-        for attr_name, attr_value in attrs.items():
-            keys.append((param_name, attr_name))
-            if isinstance(attr_value, xr.DataArray):
-                values.append(attr_value)
-            else:
-                values.append(xr.DataArray(attr_value))
-
-    return xr.apply_ufunc(
-        functools.partial(_build_params_from_values, keys=tuple(keys)),
-        *values,
-        vectorize=True,
-        dask="parallelized",
-        output_dtypes=[object],
-        join="outer",
-    )
-
-
 class _ParametersWrapper:
     """Wrapper class to pass lmfit.Parameters through xarray.apply_ufunc.
 
@@ -102,6 +40,187 @@ class _ParametersWrapper:
     def __init__(self, params: lmfit.Parameters, *, complete: bool = False) -> None:
         self.params = params
         self.complete = complete
+
+
+_ParameterSpecs = tuple[
+    tuple[str, tuple[tuple[str, typing.Any], ...]],
+    ...,
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class _ParameterPlan:
+    """Picklable instructions for constructing parameters inside a fit task."""
+
+    mode: typing.Literal["static", "broadcast", "object"]
+    template: _ParametersWrapper | None = None
+    template_specs: _ParameterSpecs = ()
+    static_specs: _ParameterSpecs = ()
+    dynamic_keys: tuple[tuple[str, str], ...] = ()
+    parameter_names: tuple[str, ...] = ()
+    base_names: tuple[str, ...] = ()
+
+
+@dataclasses.dataclass(frozen=True)
+class _ParameterInputs:
+    """Parameter plan plus xarray inputs that participate in task alignment."""
+
+    plan: _ParameterPlan
+    arrays: tuple[xr.DataArray, ...] = ()
+
+
+def _parse_params(
+    d: dict[str, typing.Any] | lmfit.Parameters,
+) -> _ParameterInputs:
+    if isinstance(d, lmfit.Parameters):
+        return _ParameterInputs(
+            _ParameterPlan(mode="static", template=_ParametersWrapper(d))
+        )
+
+    static_specs: dict[str, list[tuple[str, typing.Any]]] = {}
+    dynamic_keys: list[tuple[str, str]] = []
+    dynamic_arrays: list[xr.DataArray] = []
+    for param_name, value in d.items():
+        attrs = value if isinstance(value, Mapping) else {"value": value}
+        for attr_name, attr_value in attrs.items():
+            if isinstance(attr_value, xr.DataArray):
+                dynamic_keys.append((param_name, attr_name))
+                dynamic_arrays.append(attr_value)
+            elif not _is_missing_parameter_attr(attr_value):
+                static_specs.setdefault(param_name, []).append((attr_name, attr_value))
+
+    if not dynamic_arrays:
+        return _ParameterInputs(
+            _ParameterPlan(
+                mode="static", template=_ParametersWrapper(lmfit.create_params(**d))
+            )
+        )
+
+    dynamic_param_names = {param_name for param_name, _ in dynamic_keys}
+    has_static_expression = any(
+        attr_name == "expr" and attr_value is not None
+        for attrs in static_specs.values()
+        for attr_name, attr_value in attrs
+    )
+    if has_static_expression:
+        # Expressions can reference dynamically supplied auxiliary parameters, so all
+        # supplied attributes must be created together inside each fit task.
+        template_specs = {}
+    else:
+        template_specs = {
+            name: attrs
+            for name, attrs in static_specs.items()
+            if name not in dynamic_param_names
+        }
+        static_specs = {
+            name: attrs
+            for name, attrs in static_specs.items()
+            if name in dynamic_param_names
+        }
+
+    aligned_arrays = xr.align(*dynamic_arrays, join="outer", copy=False)
+    return _ParameterInputs(
+        _ParameterPlan(
+            mode="broadcast",
+            template_specs=tuple(
+                (name, tuple(attrs)) for name, attrs in template_specs.items()
+            ),
+            static_specs=tuple(
+                (name, tuple(attrs)) for name, attrs in static_specs.items()
+            ),
+            dynamic_keys=tuple(dynamic_keys),
+            parameter_names=tuple(d),
+        ),
+        aligned_arrays,
+    )
+
+
+def _is_missing_parameter_attr(value: typing.Any) -> bool:
+    try:
+        return bool(np.isnan(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _params_from_specs(specs: _ParameterSpecs) -> lmfit.Parameters:
+    return lmfit.create_params(
+        **{name: dict(parameter_specs) for name, parameter_specs in specs}
+    )
+
+
+def _materialize_broadcast_params(
+    plan: _ParameterPlan,
+    values: Sequence[typing.Any],
+    *,
+    guess: bool,
+) -> _ParametersWrapper:
+    supplied_specs = {name: dict(attrs) for name, attrs in plan.static_specs}
+    for (param_name, attr_name), value in zip(plan.dynamic_keys, values, strict=True):
+        if not _is_missing_parameter_attr(value):
+            supplied_specs.setdefault(param_name, {})[attr_name] = value
+    supplied_specs = {
+        name: supplied_specs[name]
+        for name in plan.parameter_names
+        if name in supplied_specs
+    }
+
+    if plan.template is None:
+        raise RuntimeError("broadcast parameter template was not initialized")
+    if not supplied_specs:
+        return plan.template
+
+    params = plan.template.params.copy()
+    per_fit_specs = tuple(
+        (name, tuple(attrs.items())) for name, attrs in supplied_specs.items()
+    )
+    params.update(_params_from_specs(per_fit_specs))
+    # Updating a prebuilt template can append dynamic auxiliary parameters after
+    # static ones. Restore their input order without rebinding the Parameters.
+    for name in plan.parameter_names:
+        if name not in plan.base_names and name in params:
+            parameter = dict.pop(params, name)
+            dict.__setitem__(params, name, parameter)
+    return _ParametersWrapper(params, complete=not guess)
+
+
+def _align_parameter_chunks(
+    data: xr.DataArray, arrays: Sequence[xr.DataArray]
+) -> tuple[xr.DataArray, ...]:
+    """Match lazy parameter chunks to data chunks without global rechunking."""
+    target_chunks: dict[Hashable, tuple[int, ...]] = {}
+    if data.chunks is not None:
+        target_chunks.update(data.chunksizes)
+
+    for array in arrays:
+        if array.chunks is not None:
+            for dim, dim_chunks in array.chunksizes.items():
+                target_chunks.setdefault(dim, dim_chunks)
+
+    aligned: list[xr.DataArray] = []
+    for array in arrays:
+        if array.chunks is None:
+            if data.chunks is not None and array.dims:
+                eager_chunks = {
+                    dim: target_chunks.get(dim, (array.sizes[dim],))
+                    for dim in array.dims
+                    if sum(target_chunks.get(dim, (array.sizes[dim],)))
+                    == array.sizes[dim]
+                }
+                aligned.append(array.chunk(eager_chunks))
+                continue
+            aligned.append(array)
+            continue
+
+        rechunk = {
+            dim: target_chunks[dim]
+            for dim in array.dims
+            if dim in target_chunks
+            and sum(target_chunks[dim]) == array.sizes[dim]
+            and array.chunksizes[dim] != target_chunks[dim]
+        }
+        aligned.append(array.chunk(rechunk) if rechunk else array)
+
+    return tuple(aligned)
 
 
 def _make_failed_model_result(
@@ -137,6 +256,7 @@ def _model_fit_wrapper(
     param_names: Sequence[str],
     stat_names: Sequence[str],
     n_coords: int,
+    parameter_plan: _ParameterPlan,
     skipna: bool,
     guess: bool,
     errors: typing.Literal["raise", "ignore"],
@@ -148,12 +268,30 @@ def _model_fit_wrapper(
     n_stats = len(stat_names)
 
     coords__ = args[:n_coords]
-    init_params_ = args[n_coords]
+    if parameter_plan.mode == "broadcast":
+        n_parameter_inputs = len(parameter_plan.dynamic_keys)
+    elif parameter_plan.mode == "object":
+        n_parameter_inputs = 1
+    else:
+        n_parameter_inputs = 0
+    parameter_values = args[n_coords : n_coords + n_parameter_inputs]
+
+    if parameter_plan.mode == "static":
+        if parameter_plan.template is None:
+            raise RuntimeError("static parameter template was not initialized")
+        init_params_: typing.Any = parameter_plan.template
+    elif parameter_plan.mode == "broadcast":
+        init_params_ = _materialize_broadcast_params(
+            parameter_plan, parameter_values, guess=guess
+        )
+    else:
+        init_params_ = parameter_values[0]
 
     fit_kwargs = dict(model_fit_kwargs) if model_fit_kwargs is not None else {}
-    if len(args) > n_coords + 1:
+    weight_arg_index = n_coords + n_parameter_inputs
+    if len(args) > weight_arg_index:
         fit_kwargs.pop("weights", None)
-        raw_weights = args[n_coords + 1]
+        raw_weights = args[weight_arg_index]
     else:
         raw_weights = fit_kwargs.pop("weights", None)
 
@@ -186,7 +324,7 @@ def _model_fit_wrapper(
         other = init_params_.params
 
         if isinstance(other, lmfit.Parameters):
-            initial_params.update(other)
+            initial_params.update(other.copy())
         else:
             # Instance check may fail in multiprocess, so forcibly set class
             # This no longer triggers in CI in python 3.14+, presumably due to
@@ -212,7 +350,7 @@ def _model_fit_wrapper(
         initial_params.update(lmfit.Parameters().loads(init_params_))
 
     elif isinstance(init_params_, lmfit.Parameters):
-        initial_params.update(init_params_)
+        initial_params.update(init_params_.copy())
 
     elif isinstance(init_params_, Mapping):
         param_specs = {
@@ -388,6 +526,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
         param_names: list[str],
         stat_names: list[str],
         n_coords: int,
+        parameter_plan: _ParameterPlan,
         skipna: bool,
         guess: bool,
         errors: typing.Literal["raise", "ignore"],
@@ -401,6 +540,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             param_names=param_names,
             stat_names=stat_names,
             n_coords=n_coords,
+            parameter_plan=parameter_plan,
             skipna=skipna,
             guess=guess,
             errors=errors,
@@ -411,7 +551,7 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
     def _define_output_wrapper(
         self,
         model: lmfit.Model,
-        params: xr.Dataset | xr.DataArray | _ParametersWrapper,
+        params: xr.Dataset | _ParameterInputs,
         reduce_dims_: list[Hashable],
         coords_,
         param_names: list[str],
@@ -419,22 +559,10 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
         output_result: bool,
         skipna: bool,
         guess: bool,
-        is_dask: bool,
         errors: typing.Literal["raise", "ignore"],
         model_fit_kwargs: Mapping[str, typing.Any],
         weight_da: xr.DataArray | None,
     ) -> typing.Callable:
-        _wrapper = self._define_wrapper(
-            model=model,
-            param_names=param_names,
-            stat_names=stat_names,
-            n_coords=len(coords_),
-            skipna=skipna,
-            guess=guess,
-            errors=errors,
-            output_result=output_result,
-            model_fit_kwargs=model_fit_kwargs,
-        )
         n_params = len(param_names)
         n_stats = len(stat_names)
         dim_sizes = {dim: self._obj.coords[dim].size for dim in reduce_dims_}
@@ -444,28 +572,38 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
 
             # Select parameters for this data variable
             if not isinstance(params, xr.Dataset):
-                params_to_apply = params
+                parameter_inputs = params
             else:
                 try:
                     params_to_apply = params[name.removesuffix("_")]
                 except KeyError:
                     params_to_apply = params[float(name.removesuffix("_"))]
-
-            if isinstance(params_to_apply, xr.DataArray) and is_dask:
-                # TODO: check whether this works with chunked datasets
-                # Since dask cannot auto-rechunk object arrays, rechunk to single chunk
-                params_to_apply = params_to_apply.chunk(
-                    dict.fromkeys(params_to_apply.dims, -1)
+                parameter_inputs = _ParameterInputs(
+                    _ParameterPlan(mode="object"), (params_to_apply,)
                 )
 
+            parameter_arrays = _align_parameter_chunks(da, parameter_inputs.arrays)
+            _wrapper = self._define_wrapper(
+                model=model,
+                param_names=param_names,
+                stat_names=stat_names,
+                n_coords=len(coords_),
+                parameter_plan=parameter_inputs.plan,
+                skipna=skipna,
+                guess=guess,
+                errors=errors,
+                output_result=output_result,
+                model_fit_kwargs=model_fit_kwargs,
+            )
+
             # Positional arguments to wrapper
-            args = [da, *coords_, params_to_apply]
+            args = [da, *coords_, *parameter_arrays]
 
             # Core dims for data & coords
             input_core_dims = [reduce_dims_ for _ in range(len(coords_) + 1)]
 
             # Core dims for parameters
-            input_core_dims.append([])
+            input_core_dims.extend([] for _ in parameter_arrays)
 
             if isinstance(weight_da, xr.DataArray):
                 weights = weight_da.broadcast_like(da)
@@ -661,19 +799,53 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
         if params is None:
             params = lmfit.create_params()
 
-        is_dask: bool = bool(self._obj.chunks)
-
         if not isinstance(params, xr.Dataset) and isinstance(params, Mapping):
             # Given as a mapping from str to ...
             # float or DataArray or dict of str to Any (including DataArray of Any)
             params = _parse_params(params)
-            # Now, params is either a _ParametersWrapper or a DataArray of Parameters
+        elif isinstance(params, xr.DataArray):
+            params = _ParameterInputs(_ParameterPlan(mode="object"), (params,))
+        elif isinstance(params, _ParametersWrapper):
+            params = _ParameterInputs(_ParameterPlan(mode="static", template=params))
 
         model_params: lmfit.Parameters | None = None
-        if isinstance(params, _ParametersWrapper) and not guess:
+        if (
+            isinstance(params, _ParameterInputs)
+            and params.plan.mode in {"static", "broadcast"}
+            and not guess
+        ):
             model_params = model.make_params()
-            model_params.update(params.params)
-            params = _ParametersWrapper(model_params, complete=True)
+            base_names = tuple(model_params)
+            if params.plan.mode == "static":
+                if params.plan.template is None:
+                    raise RuntimeError("static parameter template was not initialized")
+                # Parameters.update() rebinds each Parameter to its destination's
+                # expression evaluator, so never update from caller-owned objects.
+                model_params.update(params.plan.template.params.copy())
+            elif params.plan.template_specs:
+                model_params.update(_params_from_specs(params.plan.template_specs))
+            params = dataclasses.replace(
+                params,
+                plan=dataclasses.replace(
+                    params.plan,
+                    template=_ParametersWrapper(model_params, complete=True),
+                    base_names=base_names,
+                ),
+            )
+        elif (
+            isinstance(params, _ParameterInputs)
+            and params.plan.mode == "broadcast"
+            and guess
+        ):
+            params = dataclasses.replace(
+                params,
+                plan=dataclasses.replace(
+                    params.plan,
+                    template=_ParametersWrapper(
+                        _params_from_specs(params.plan.template_specs)
+                    ),
+                ),
+            )
 
         reduce_dims_: list[Hashable]
         if not reduce_dims:
@@ -709,14 +881,17 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             )
 
         # Check that initial guess and bounds only contain coords in preserved_dims
-        if isinstance(params, xr.DataArray | xr.Dataset):
-            unexpected = set(params.dims) - set(preserved_dims)
-            if unexpected:
-                raise ValueError(
-                    f"Parameters object has unexpected dimensions {tuple(unexpected)}. "
-                    "It should only have dimensions that are in data dimensions "
-                    f"{preserved_dims}."
-                )
+        if isinstance(params, xr.Dataset):
+            parameter_dims = set(params.dims)
+        else:
+            parameter_dims = {dim for array in params.arrays for dim in array.dims}
+        unexpected = parameter_dims - set(preserved_dims)
+        if unexpected:
+            raise ValueError(
+                f"Parameters object has unexpected dimensions {tuple(unexpected)}. "
+                "It should only have dimensions that are in data dimensions "
+                f"{preserved_dims}."
+            )
 
         if errors not in ["raise", "ignore"]:
             raise ValueError('errors must be either "raise" or "ignore"')
@@ -763,7 +938,6 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             output_result=output_result,
             skipna=skipna,
             guess=guess,
-            is_dask=is_dask,
             errors=errors,
             model_fit_kwargs=model_fit_kwargs,
             weight_da=weight_da,

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -207,8 +207,7 @@ def _model_fit_wrapper(
     perr = np.full([n_params], np.nan)
     pcov = np.full([n_params, n_params], np.nan)
     stats = np.full([n_stats], np.nan)
-    data = Y.copy()
-    best = np.full(data.shape, np.nan, dtype=np.float64)
+    best = np.full(Y.shape, np.nan, dtype=np.float64)
 
     x = np.vstack([c.ravel() for c in coords__])
     y: npt.NDArray = Y.ravel()
@@ -246,11 +245,11 @@ def _model_fit_wrapper(
     if skipna and not len(y):
         # No data to fit
         if not output_result:
-            return popt, perr, pcov, stats, data, best
+            return popt, perr, pcov, stats, best
         modres = _make_failed_model_result(
             model, initial_params, y, weights_, indep_var_kwargs
         )
-        return popt, perr, pcov, stats, data, best, modres
+        return popt, perr, pcov, stats, best, modres
 
     if guess:
         if isinstance(model, lmfit.model.CompositeModel):
@@ -284,11 +283,11 @@ def _model_fit_wrapper(
         if errors == "raise":
             raise
         if not output_result:
-            return popt, perr, pcov, stats, data, best
+            return popt, perr, pcov, stats, best
         modres = _make_failed_model_result(
             model, initial_params, y, weights_, indep_var_kwargs
         )
-        return popt, perr, pcov, stats, data, best, modres
+        return popt, perr, pcov, stats, best, modres
     else:
         if modres.success:
             popt_list, perr_list = [], []
@@ -331,7 +330,7 @@ def _model_fit_wrapper(
 
             best.flat[mask] = modres.best_fit  # type: ignore[index, unused-ignore]
 
-    outputs = (popt, perr, pcov, stats, data, best)
+    outputs = (popt, perr, pcov, stats, best)
     if output_result:
         return (*outputs, modres)
     return outputs
@@ -439,9 +438,8 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
                 ["cov_i", "cov_j"],
                 ["fit_stat"],
                 reduce_dims_,
-                reduce_dims_,
             ]
-            output_dtypes: list[typing.Any] = [np.float64] * 6
+            output_dtypes: list[typing.Any] = [np.float64] * 5
             if output_result:
                 output_core_dims.append([])
                 output_dtypes.append(lmfit.model.ModelResult)
@@ -465,10 +463,15 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
                 output_dtypes=output_dtypes,
                 exclude_dims=set(reduce_dims_),
             )
-            popt, perr, pcov, stats, data, best = outputs[:6]
+            popt, perr, pcov, stats, best = outputs[:5]
 
             if output_result:
-                out[name + "modelfit_results"] = outputs[6]
+                out[name + "modelfit_results"] = outputs[5]
+
+            data_dims = [dim for dim in da.dims if dim not in reduce_dims_]
+            data_dims.extend(dim for dim in reduce_dims_ if dim in da.dims)
+            data = da.transpose(*data_dims).astype(np.float64, copy=False)
+            data.attrs = popt.attrs.copy()
 
             out[name + "modelfit_coefficients"] = popt
             out[name + "modelfit_stderr"] = perr

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -209,7 +209,11 @@ def _model_fit_wrapper(
     stats = np.full([n_stats], np.nan)
     best = np.full(Y.shape, np.nan, dtype=np.float64)
 
-    x = np.vstack([c.ravel() for c in coords__])
+    single_coord = n_coords == 1
+    if single_coord:
+        x = coords__[0].ravel()
+    else:
+        x = np.vstack([c.ravel() for c in coords__])
     y: npt.NDArray = Y.ravel()
 
     if isinstance(weights_, np.ndarray) and weights_.size != y.size:
@@ -218,14 +222,21 @@ def _model_fit_wrapper(
             f"received {weights_.size} weights for {y.size} data points"
         )
 
+    mask: npt.NDArray[np.bool_] | None = None
     if skipna:
-        mask = ~np.isnan(y) & ~np.isnan(x).any(axis=0)
-        x = x[:, mask]
-        y = y[mask]
-        if isinstance(weights_, np.ndarray):
-            weights_ = weights_[mask]
-    else:
-        mask = np.ones_like(y, dtype=bool)
+        mask = ~np.isnan(y)
+        if single_coord:
+            mask &= ~np.isnan(x)
+        else:
+            mask &= ~np.isnan(x).any(axis=0)
+
+        if mask.all():
+            mask = None
+        else:
+            x = x[mask] if single_coord else x[:, mask]
+            y = y[mask]
+            if isinstance(weights_, np.ndarray):
+                weights_ = weights_[mask]
 
     x = np.squeeze(x)
 
@@ -328,7 +339,10 @@ def _model_fit_wrapper(
                                 j = param_names.index(var_names[vj])
                                 pcov[i, j] = modres.covar[vi, vj]
 
-            best.flat[mask] = modres.best_fit  # type: ignore[index, unused-ignore]
+            if mask is None:
+                best.flat[:] = modres.best_fit
+            else:
+                best.flat[mask] = modres.best_fit  # type: ignore[index, unused-ignore]
 
     outputs = (popt, perr, pcov, stats, best)
     if output_result:

--- a/src/xarray_lmfit/modelfit.py
+++ b/src/xarray_lmfit/modelfit.py
@@ -99,8 +99,9 @@ class _ParametersWrapper:
     to xarray.apply_ufunc, we wrap lmfit.Parameters in this class.
     """
 
-    def __init__(self, params: lmfit.Parameters) -> None:
+    def __init__(self, params: lmfit.Parameters, *, complete: bool = False) -> None:
         self.params = params
+        self.complete = complete
 
 
 def _make_failed_model_result(
@@ -109,8 +110,12 @@ def _make_failed_model_result(
     data: npt.NDArray,
     weights: npt.NDArray | complex | None,
     independent_vars: Mapping[str, typing.Any],
+    *,
+    copy_params: bool = False,
 ) -> lmfit.model.ModelResult:
     """Create a failed result that can be serialized and reconstructed by lmfit."""
+    if copy_params:
+        initial_params = initial_params.copy()
     modres = lmfit.model.ModelResult(
         model,
         initial_params,
@@ -162,9 +167,22 @@ def _model_fit_wrapper(
         else:
             weights_ = weights_array.ravel()
 
-    initial_params = lmfit.create_params() if guess else model.make_params()
+    wrapped_params = (
+        init_params_.params if isinstance(init_params_, _ParametersWrapper) else None
+    )
+    uses_shared_template = (
+        isinstance(init_params_, _ParametersWrapper)
+        and init_params_.complete
+        and isinstance(wrapped_params, lmfit.Parameters)
+        and not guess
+    )
+    initial_params: lmfit.Parameters
+    if uses_shared_template:
+        initial_params = typing.cast("lmfit.Parameters", wrapped_params)
+    else:
+        initial_params = lmfit.create_params() if guess else model.make_params()
 
-    if isinstance(init_params_, _ParametersWrapper):
+    if isinstance(init_params_, _ParametersWrapper) and not uses_shared_template:
         other = init_params_.params
 
         if isinstance(other, lmfit.Parameters):
@@ -258,7 +276,12 @@ def _model_fit_wrapper(
         if not output_result:
             return popt, perr, pcov, stats, best
         modres = _make_failed_model_result(
-            model, initial_params, y, weights_, indep_var_kwargs
+            model,
+            initial_params,
+            y,
+            weights_,
+            indep_var_kwargs,
+            copy_params=uses_shared_template,
         )
         return popt, perr, pcov, stats, best, modres
 
@@ -296,7 +319,12 @@ def _model_fit_wrapper(
         if not output_result:
             return popt, perr, pcov, stats, best
         modres = _make_failed_model_result(
-            model, initial_params, y, weights_, indep_var_kwargs
+            model,
+            initial_params,
+            y,
+            weights_,
+            indep_var_kwargs,
+            copy_params=uses_shared_template,
         )
         return popt, perr, pcov, stats, best, modres
     else:
@@ -641,6 +669,12 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
             params = _parse_params(params)
             # Now, params is either a _ParametersWrapper or a DataArray of Parameters
 
+        model_params: lmfit.Parameters | None = None
+        if isinstance(params, _ParametersWrapper) and not guess:
+            model_params = model.make_params()
+            model_params.update(params.params)
+            params = _ParametersWrapper(model_params, complete=True)
+
         reduce_dims_: list[Hashable]
         if not reduce_dims:
             reduce_dims_ = []
@@ -695,7 +729,8 @@ class ModelFitDatasetAccessor(XLMDatasetAccessor):
 
         if param_names is None:
             # Call make_params before getting parameter names as it may add param hints
-            model.make_params()
+            if model_params is None:
+                model_params = model.make_params()
 
             # Get the parameter names (assume no expressions)
             param_names = model.param_names

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -124,6 +124,61 @@ def test_da_modelfit_skipna_false_best_fit() -> None:
     np.testing.assert_allclose(fit.modelfit_best_fit, da)
 
 
+@pytest.mark.parametrize("skipna", [True, False], ids=["skipna", "keep-nan"])
+@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no-dask"])
+def test_da_modelfit_complete_multidimensional_core(
+    skipna: bool, use_dask: bool
+) -> None:
+    full_coord = np.arange(12.0).reshape(2, 6)
+    coord = full_coord[:, ::2]
+    da = xr.DataArray(linear(full_coord, 2.0, 1.0), dims=("row", "column")).isel(
+        column=slice(None, None, 2)
+    )
+    if use_dask:
+        da = da.chunk({"row": -1, "column": -1})
+
+    fit = da.xlm.modelfit(
+        coords=xr.DataArray(coord, dims=da.dims),
+        reduce_dims=da.dims,
+        model=lmfit.Model(linear),
+        params={"slope": 1.0, "intercept": 0.0},
+        weights=np.ones_like(coord),
+        skipna=skipna,
+        output_result=False,
+    ).compute()
+
+    np.testing.assert_allclose(fit.modelfit_coefficients, [2.0, 1.0])
+    np.testing.assert_allclose(fit.modelfit_best_fit, da)
+
+
+@pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no-dask"])
+def test_da_modelfit_single_coord_mask_aligns_weights(use_dask: bool) -> None:
+    coord = np.arange(7.0)
+    values = linear(coord, 2.0, 1.0)
+    coord[1] = np.nan
+    values[4] = np.nan
+    da = xr.DataArray(values, dims="point")
+    if use_dask:
+        da = da.chunk({"point": -1})
+
+    fit = da.xlm.modelfit(
+        coords=xr.DataArray(coord, dims="point"),
+        reduce_dims="point",
+        model=lmfit.Model(linear),
+        params={"slope": 1.0, "intercept": 0.0},
+        weights=np.arange(1.0, 8.0),
+        output_result=False,
+    ).compute()
+
+    np.testing.assert_allclose(fit.modelfit_coefficients, [2.0, 1.0])
+    assert fit.modelfit_stats.sel(fit_stat="ndata") == 5
+    assert np.isnan(fit.modelfit_best_fit[[1, 4]]).all()
+    np.testing.assert_allclose(
+        fit.modelfit_best_fit[[0, 2, 3, 5, 6]],
+        linear(np.array([0.0, 2.0, 3.0, 5.0, 6.0]), 2.0, 1.0),
+    )
+
+
 @pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
 def test_da_modelfit_integer_best_fit(use_dask: bool) -> None:
     x = np.arange(5.0)

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -252,11 +252,57 @@ def test_da_modelfit_without_model_results(
         output_result=False,
     ).compute()
 
-    assert output_dtypes == [(np.float64,) * 6]
+    assert output_dtypes == [(np.float64,) * 5]
     assert "modelfit_results" not in fit
     assert all(variable.dtype != object for variable in fit.data_vars.values())
     np.testing.assert_allclose(fit.modelfit_coefficients[0], [2.0, 1.0])
     assert np.isnan(fit.modelfit_coefficients[1]).all()
+
+
+def test_modelfit_data_bypasses_fit_graph() -> None:
+    fit_calls = 0
+
+    def counted_linear(x, slope, intercept):
+        nonlocal fit_calls
+        fit_calls += 1
+        return linear(x, slope, intercept)
+
+    x = np.arange(5, dtype=float)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 1.0), linear(x, -1.0, 3.0)]).T.astype(np.int64),
+        dims=("x", "fit"),
+        coords={"fit": [0, 1], "x": x, "label": ("fit", ["a", "b"])},
+        attrs={"description": "input data"},
+    ).chunk({"fit": 1, "x": -1})
+
+    with xr.set_options(keep_attrs=False):
+        result = da.xlm.modelfit(
+            "x",
+            model=lmfit.Model(counted_linear),
+            params={"slope": 1.0, "intercept": 0.0},
+            output_result=False,
+        )
+
+    actual = result.modelfit_data.compute(scheduler="single-threaded")
+    expected = da.transpose("fit", "x").astype(np.float64).compute()
+    expected.name = "modelfit_data"
+    expected.attrs = {}
+
+    xr.testing.assert_identical(actual, expected)
+    assert fit_calls == 0
+
+    result.modelfit_coefficients.compute(scheduler="single-threaded")
+    assert fit_calls > 0
+
+    with xr.set_options(keep_attrs=True):
+        result_with_attrs = da.xlm.modelfit(
+            "x",
+            model=lmfit.Model(counted_linear),
+            params={"slope": 1.0, "intercept": 0.0},
+            output_result=False,
+        )
+
+    assert result_with_attrs.modelfit_data.attrs == da.attrs
 
 
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -403,6 +403,7 @@ def test_failed_results_do_not_share_static_parameter_template() -> None:
         coords={"fit": [0, 1], "x": x},
     )
     supplied = lmfit.create_params(slope=1.0, intercept=0.0)
+    assert supplied["slope"]._expr_eval is supplied._asteval
 
     fit = da.xlm.modelfit(
         "x",
@@ -414,6 +415,7 @@ def test_failed_results_do_not_share_static_parameter_template() -> None:
     first.params["slope"].value = 10.0
     assert second.params["slope"].value == 1.0
     assert supplied["slope"].value == 1.0
+    assert supplied["slope"]._expr_eval is supplied._asteval
 
 
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])
@@ -645,6 +647,349 @@ def test_modelfit_lazy_broadcast_params() -> None:
         fit.compute().modelfit_coefficients,
         [[0.0, 5.0], [0.0, 1.0]],
     )
+
+
+def test_modelfit_broadcast_parameter_chunks_follow_data() -> None:
+    x = np.arange(5.0)
+    slopes = np.arange(1.0, 7.0)
+    da = xr.DataArray(
+        np.stack([linear(x, slope, 1.0) for slope in slopes]),
+        dims=("fit", "x"),
+        coords={"fit": np.arange(slopes.size), "x": x},
+    ).chunk({"fit": 3, "x": -1})
+    slope_guess = xr.DataArray(
+        np.zeros(slopes.size), dims="fit", coords={"fit": da.fit}
+    ).chunk({"fit": 1})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params={"slope": slope_guess, "intercept": 0.0},
+        output_result=False,
+    )
+
+    assert fit.modelfit_coefficients.chunks == ((3, 3), (2,))
+    graph = fit.modelfit_coefficients.data.__dask_graph__()
+    assert all(
+        len(layer) > 1
+        for name, layer in graph.layers.items()
+        if name.startswith("rechunk-merge")
+    )
+    np.testing.assert_allclose(
+        fit.compute().modelfit_coefficients.sel(param="slope"), slopes
+    )
+
+
+def test_modelfit_object_parameter_chunks_follow_data() -> None:
+    x = np.arange(5.0)
+    slopes = np.arange(1.0, 7.0)
+    da = xr.DataArray(
+        np.stack([linear(x, slope, 1.0) for slope in slopes]),
+        dims=("fit", "x"),
+        coords={"fit": np.arange(slopes.size), "x": x},
+    ).chunk({"fit": 3, "x": -1})
+    specs = np.empty(slopes.size, dtype=object)
+    specs[:] = [{"slope": 0.0, "intercept": 0.0}] * slopes.size
+    params = xr.DataArray(specs, dims="fit", coords={"fit": da.fit}).chunk({"fit": 1})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params=params,
+        output_result=False,
+    )
+
+    assert fit.modelfit_coefficients.chunks == ((3, 3), (2,))
+    np.testing.assert_allclose(
+        fit.compute().modelfit_coefficients.sel(param="slope"), slopes
+    )
+
+
+def test_modelfit_broadcast_params_preserve_outer_alignment() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 10.0)] * 3),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1, 2], "x": x},
+    )
+    model = lmfit.Model(linear)
+    model.set_param_hint("slope", value=5.0)
+    model.set_param_hint("intercept", value=10.0)
+    slope = xr.DataArray([2.0, 4.0], dims="fit", coords={"fit": [0, 1]})
+    intercept = xr.DataArray([1.0, 3.0], dims="fit", coords={"fit": [1, 2]})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=model,
+        params={"slope": slope, "intercept": intercept},
+    )
+
+    initial_values = np.array(
+        [
+            [result.init_params["slope"].value, result.init_params["intercept"].value]
+            for result in fit.modelfit_results.values
+        ]
+    )
+    np.testing.assert_allclose(initial_values, [[2.0, 10.0], [4.0, 1.0], [5.0, 3.0]])
+
+
+@pytest.mark.parametrize("guess", [False, True])
+def test_modelfit_broadcast_params_omit_static_nan(guess: bool) -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 10.0)] * 2),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    model = lmfit.Model(linear)
+    model.set_param_hint("intercept", value=10.0)
+    slope = xr.DataArray([2.0, 2.0], dims="fit", coords={"fit": da.fit})
+
+    if guess:
+        with pytest.warns(UserWarning, match="`guess` is not implemented"):
+            fit = da.xlm.modelfit(
+                "x",
+                model=model,
+                params={"slope": slope, "intercept": np.nan},
+                guess=True,
+            )
+    else:
+        fit = da.xlm.modelfit(
+            "x",
+            model=model,
+            params={"slope": slope, "intercept": np.nan},
+        )
+
+    assert all(
+        result.init_params["intercept"].value == 10.0
+        for result in fit.modelfit_results.values
+    )
+
+
+def test_modelfit_broadcast_partial_attribute_replaces_model_hint() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.full((2, x.size), np.nan),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    model = lmfit.Model(linear)
+    model.set_param_hint("slope", value=7.0, min=1.0, max=9.0, vary=False)
+    minimum = xr.DataArray([3.0, np.nan], dims="fit", coords={"fit": da.fit})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=model,
+        params={"slope": {"min": minimum}},
+    )
+
+    replaced = fit.modelfit_results.values[0].init_params["slope"]
+    preserved = fit.modelfit_results.values[1].init_params["slope"]
+    assert (replaced.value, replaced.min, replaced.max, replaced.vary) == (
+        3.0,
+        3.0,
+        np.inf,
+        True,
+    )
+    assert (preserved.value, preserved.min, preserved.max, preserved.vary) == (
+        7.0,
+        1.0,
+        9.0,
+        False,
+    )
+
+
+def test_modelfit_broadcast_params_preserve_auxiliary_order() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.full((2, x.size), np.nan),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    dynamic_aux = xr.DataArray([1.0, 2.0], dims="fit", coords={"fit": da.fit})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params={
+            "dynamic_aux": {"value": dynamic_aux, "vary": False},
+            "static_aux": {"value": 3.0, "vary": False},
+        },
+    )
+
+    for result in fit.modelfit_results.values:
+        assert list(result.init_params) == [
+            "slope",
+            "intercept",
+            "dynamic_aux",
+            "static_aux",
+        ]
+
+
+def test_modelfit_broadcast_auxiliary_expression_parameter() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 3.0), linear(x, 2.0, 4.0)]),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    ).chunk({"fit": 1, "x": -1})
+    delta = xr.DataArray([1.0, 2.0], dims="fit", coords={"fit": da.fit}).chunk(
+        {"fit": 1}
+    )
+    params = {
+        "slope": 2.0,
+        "delta": delta,
+        "intercept": {"expr": "slope + delta"},
+    }
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params=params,
+        param_names=["slope", "intercept", "delta"],
+        output_result=False,
+    ).compute()
+
+    np.testing.assert_allclose(
+        fit.modelfit_coefficients, [[2.0, 3.0, 1.0], [2.0, 4.0, 2.0]]
+    )
+    assert "is_init_value" not in params["intercept"]
+
+
+def test_modelfit_broadcast_params_across_dimensions() -> None:
+    x = np.arange(5.0)
+    slopes = xr.DataArray([1.0, 2.0], dims="row").chunk({"row": 1})
+    intercepts = xr.DataArray([10.0, 20.0, 30.0], dims="column").chunk({"column": 1})
+    values = (
+        slopes.compute().values[:, np.newaxis, np.newaxis] * x
+        + intercepts.compute().values[np.newaxis, :, np.newaxis]
+    )
+    da = xr.DataArray(
+        values,
+        dims=("row", "column", "x"),
+        coords={"x": x},
+    ).chunk({"row": 1, "column": 2, "x": -1})
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params={"slope": slopes, "intercept": intercepts},
+        output_result=False,
+    ).compute()
+
+    expected_slope, expected_intercept = xr.broadcast(
+        slopes.compute(), intercepts.compute()
+    )
+    np.testing.assert_allclose(
+        fit.modelfit_coefficients.sel(param="slope"), expected_slope
+    )
+    np.testing.assert_allclose(
+        fit.modelfit_coefficients.sel(param="intercept"), expected_intercept
+    )
+
+
+def test_modelfit_broadcast_params_override_guesses() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, 2.0, 1.0), linear(x, -1.0, 3.0)]),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    slope = xr.DataArray([0.0, 0.0], dims="fit", coords={"fit": da.fit}).chunk(
+        {"fit": 1}
+    )
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.models.LinearModel(),
+        params={"slope": {"value": slope, "vary": False}},
+        guess=True,
+        output_result=False,
+    ).compute()
+
+    np.testing.assert_allclose(fit.modelfit_coefficients, [[0.0, 5.0], [0.0, 1.0]])
+
+
+def test_modelfit_dataset_with_different_chunk_layouts() -> None:
+    x = np.arange(5.0)
+    values = np.stack([linear(x, slope, 1.0) for slope in range(1, 5)])
+    ds = xr.Dataset(
+        {
+            "a": xr.DataArray(values, dims=("fit", "x")).chunk({"fit": 1, "x": -1}),
+            "b": xr.DataArray(values, dims=("fit", "x")).chunk({"fit": 2, "x": -1}),
+        },
+        coords={"fit": np.arange(4), "x": x},
+    )
+    slope_guess = xr.DataArray(np.zeros(4), dims="fit", coords={"fit": ds.fit}).chunk(
+        {"fit": 1}
+    )
+
+    fit = ds.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params={"slope": slope_guess, "intercept": 0.0},
+        output_result=False,
+    )
+
+    assert fit.a_modelfit_coefficients.chunks == ((1, 1, 1, 1), (2,))
+    assert fit.b_modelfit_coefficients.chunks == ((2, 2), (2,))
+    expected = np.arange(1.0, 5.0)
+    computed = fit.compute()
+    np.testing.assert_allclose(
+        computed.a_modelfit_coefficients.sel(param="slope"), expected
+    )
+    np.testing.assert_allclose(
+        computed.b_modelfit_coefficients.sel(param="slope"), expected
+    )
+
+
+def test_modelfit_parameter_dataset_supports_mixed_object_specs() -> None:
+    x = np.arange(5.0)
+    slopes = np.arange(1.0, 4.0)
+    values = np.stack([linear(x, slope, 1.0) for slope in slopes])
+    ds = xr.Dataset(
+        {
+            "a": xr.DataArray(values, dims=("fit", "x")).chunk({"fit": 1, "x": -1}),
+            "b": xr.DataArray(values, dims=("fit", "x")).chunk({"fit": 2, "x": -1}),
+        },
+        coords={"fit": np.arange(slopes.size), "x": x},
+    )
+    supplied_a = lmfit.create_params(slope=0.0, intercept=0.0)
+    supplied_b = lmfit.create_params(slope=0.0, intercept=0.0)
+    dict_spec = {"slope": 0.0, "intercept": 0.0}
+    json_spec = lmfit.create_params(slope=0.0, intercept=0.0).dumps()
+    a_specs = np.empty(slopes.size, dtype=object)
+    b_specs = np.empty(slopes.size, dtype=object)
+    for i, spec in enumerate((dict_spec, supplied_a, json_spec)):
+        a_specs[i] = spec
+    for i, spec in enumerate((json_spec, dict_spec, supplied_b)):
+        b_specs[i] = spec
+    params = xr.Dataset(
+        {
+            "a": xr.DataArray(a_specs, dims="fit").chunk({"fit": 2}),
+            "b": xr.DataArray(b_specs, dims="fit").chunk({"fit": 1}),
+        },
+        coords={"fit": ds.fit},
+    )
+
+    fit = ds.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params=params,
+        output_result=False,
+    )
+
+    assert fit.a_modelfit_coefficients.chunks == ((1, 1, 1), (2,))
+    assert fit.b_modelfit_coefficients.chunks == ((2, 1), (2,))
+    computed = fit.compute()
+    np.testing.assert_allclose(
+        computed.a_modelfit_coefficients.sel(param="slope"), slopes
+    )
+    np.testing.assert_allclose(
+        computed.b_modelfit_coefficients.sel(param="slope"), slopes
+    )
+    assert supplied_a["slope"]._expr_eval is supplied_a._asteval
+    assert supplied_b["slope"]._expr_eval is supplied_b._asteval
 
 
 def test_modelfit_does_not_deepcopy_parameter_dataarrays() -> None:

--- a/tests/test_modelfit.py
+++ b/tests/test_modelfit.py
@@ -360,6 +360,62 @@ def test_modelfit_data_bypasses_fit_graph() -> None:
     assert result_with_attrs.modelfit_data.attrs == da.attrs
 
 
+def test_modelfit_builds_static_parameter_template_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    make_params_calls = 0
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.stack([linear(x, slope, 1.0) for slope in range(1, 6)]),
+        dims=("fit", "x"),
+        coords={"fit": np.arange(5), "x": x},
+    )
+    model = lmfit.Model(linear)
+    model.set_param_hint("slope", min=0.0)
+    original_make_params = model.make_params
+
+    def counted_make_params(*args, **kwargs):
+        nonlocal make_params_calls
+        make_params_calls += 1
+        return original_make_params(*args, **kwargs)
+
+    monkeypatch.setattr(model, "make_params", counted_make_params)
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=model,
+        params={"slope": 1.0, "intercept": 0.0},
+        output_result=False,
+    )
+
+    assert make_params_calls == 1
+    np.testing.assert_allclose(
+        fit.modelfit_coefficients.sel(param="slope"), np.arange(1.0, 6.0)
+    )
+    assert make_params_calls == 1
+
+
+def test_failed_results_do_not_share_static_parameter_template() -> None:
+    x = np.arange(5.0)
+    da = xr.DataArray(
+        np.full((2, x.size), np.nan),
+        dims=("fit", "x"),
+        coords={"fit": [0, 1], "x": x},
+    )
+    supplied = lmfit.create_params(slope=1.0, intercept=0.0)
+
+    fit = da.xlm.modelfit(
+        "x",
+        model=lmfit.Model(linear),
+        params=supplied,
+    )
+    first, second = fit.modelfit_results.values
+
+    first.params["slope"].value = 10.0
+    assert second.params["slope"].value == 1.0
+    assert supplied["slope"].value == 1.0
+
+
 @pytest.mark.parametrize("progress", [True, False], ids=["tqdm", "no_tqdm"])
 @pytest.mark.parametrize("use_dask", [True, False], ids=["dask", "no_dask"])
 def test_ds_modelfit(


### PR DESCRIPTION
## Summary

- expose `modelfit_data` directly instead of rerunning fit tasks to reproduce the input
- avoid redundant stacking, masking, and copies for complete single-coordinate fits
- build and reuse complete static parameter templates across repeated fits
- construct broadcast parameters inside fit tasks instead of materializing object arrays ahead of time
- align lazy parameter chunks with each fitted variable without a global single-chunk barrier

## Why

The fitting path performed avoidable model evaluations and array copies, recreated unchanged parameter collections for every fit, and eagerly constructed large object arrays for broadcast parameters. For lazy inputs, this increased graph-construction time and memory use and could introduce an unnecessarily global rechunk step.

The broadcast implementation remains compatible with missing parameter attributes, model hints, `guess=True`, expressions and auxiliary parameters, mixed Dataset chunk layouts, caller-owned `lmfit.Parameters`, and observable parameter ordering.

In a local 5,000-fit parameter-construction microbenchmark, setup dropped from approximately 2.32 seconds and 112.7 MiB peak memory to 0.0003 seconds and 0.021 MiB.

## User impact

Repeated and lazy fits require less setup work and memory while preserving the existing output schema and fitting semantics. Accessing only `modelfit_data` no longer evaluates the model.

## Validation

- `uv run pytest -q` — 61 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy .`
- `uv run --python 3.14 --with mypy==2.2.0 --with numpy==2.5.1 mypy .`
